### PR TITLE
various enhancements

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -13,7 +13,7 @@
 运行以下命令来安装依赖项：
 
 ```bash
-pip install -i requirements.txt
+pip install -r requirements.txt
 ```
 
 或者手动安装依赖项：
@@ -22,7 +22,7 @@ pip install -i requirements.txt
 | ---------------------------------------------- |
 | [pytumblr](https://github.com/tumblr/pytumblr) |
 | requests                                       |
-| yaml                                           |
+| pyyaml                                         |
 | beautifulsoup4                                 |
 | lxml                                           |
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,19 @@ Or install the requirements manually:
 | download_following()                     | Download all the posts in the blogs you are following |
 | download_blog(`name or url of the blog`) | Download all the posts in the blog you specified      |
 
-- The functions has two optional parameters: `start_page` and `max_page`. `start_page` is the page number to start; `max_page` is the max page number to download in case it takes too much time downloading one blog. `max_page` cannot be larger than 50, since downloader cannot access 50 and more pages via tumblr API. 
+- `download_blog`'s required parameter is the name or URL of the blog. Take [support](https://support.tumblr.com/) blog as an example, the blog name should be `support`, and the URL should be `support.tumblr.com`.
 
-  > When using the offset parameter the maximum limit on the offset is 1000. If you would like to get more results than that use either before or after.
+- `download_likes` and `download_blogs` have an optional parameter `before_timestamp` which, if set, starts downloading from a certain (unix epoch) timestamp proceeding earlier.  If unset, everything is downloaded.
 
 - `download_likes` has another optional parameter: `use_native_filenames`.  When False (default), the downloaded files are named for the blog that posted the liked file.  When True, the raw / native filename is used.
 
-- `download_following` has another optional parameters: `start_blog`, which you can use it to specify which blog to start. This is useful when the script breaks down and you want to resume it.
+- `download_following` has some optional parameters:
 
-- the parameter of `download_blog` is the name or URL of the blog. Take [support](https://support.tumblr.com/) blog as an example, the blog name should be `support`, and the URL should be `support.tumblr.com`.
+  > `start_blog`, which you can use it to specify which blog to start. This is useful when the script breaks down and you want to resume it.
+  > `start_page` is the page number to start.
+  > `max_page` is the max page number to download in case it takes too much time
+downloading one blog. `max_page` cannot be larger than 50, since downloader cannot access 50 and more pages via tumblr API.
+  > When using the offset parameter the maximum limit on the offset is 1000. If you would like to get more results than that use either before or after.
 
 - Set the downloader to not download reblog posts by setting`downloader.reblog = False`.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Or install the requirements manually:
 
   > When using the offset parameter the maximum limit on the offset is 1000. If you would like to get more results than that use either before or after.
 
+- `download_likes` has another optional parameter: `use_native_filenames`.  When False (default), the downloaded files are named for the blog that posted the liked file.  When True, the raw / native filename is used.
+
 - `download_following` has another optional parameters: `start_blog`, which you can use it to specify which blog to start. This is useful when the script breaks down and you want to resume it.
 
 - the parameter of `download_blog` is the name or URL of the blog. Take [support](https://support.tumblr.com/) blog as an example, the blog name should be `support`, and the URL should be `support.tumblr.com`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Require Python >= 3.5, you can install the python from [official website](https:
 Install the requirement by: 
 
 ```bash
-pip install -i requirements.txt
+pip install -r requirements.txt
 ```
 
 Or install the requirements manually: 
@@ -22,7 +22,7 @@ Or install the requirements manually:
 | ---------------------------------------------- |
 | [pytumblr](https://github.com/tumblr/pytumblr) |
 | requests                                       |
-| yaml                                           |
+| pyyaml                                         |
 | beautifulsoup4                                 |
 | lxml                                           |
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Or install the requirements manually:
 
 - Set the downloader to not download reblog posts by setting`downloader.reblog = False`.
 
+- Set the downloader to not download content that has already been downloaded, say from a previous run, by setting `downloader.redownload = False`.
+
 4. Run `python main.py` to start the first-time config, you will be redirected to a interactive console provided by pytumblr. 
    1. First input the OAuth Consumer Key and Secret Key you get before.
    2. The console will return <u>an authorize url</u> to authorize your own tumblr account to the downloader. Copy and paste it in web browser and visit it. The page will ask you to authorize. Allow it. Then the url will be redirected to another url, which contains the `oauth_verifier` token, copy and paste it back to the console.

--- a/main.py
+++ b/main.py
@@ -4,6 +4,9 @@ if __name__ == '__main__':
     # Init a downloader
     d = TumblrDownloader()
 
+    # Do not download content already downloaded
+    d.redownload = False
+
     # Download all the posts you liked
     d.download_likes()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytumblr
 requests
-yaml
+pyyaml
 beautifulsoup4
 lxml

--- a/tumblr.py
+++ b/tumblr.py
@@ -15,7 +15,7 @@ MAX_RETRY = 20
 
 class TumblrDownloader:
 
-    def __init__(self, reblog: bool = True, logging_level: str = 'INFO'):
+    def __init__(self, reblog: bool = True, redownload: bool = False, logging_level: str = 'INFO'):
         """
         :param reblog: Download the reblog posts or not
         :param logging_level: the level of logging information
@@ -25,6 +25,7 @@ class TumblrDownloader:
                             level=getattr(logging, logging_level))
 
         self.reblog = reblog
+        self.redownload = redownload
 
         # Get Token from file or interactive console
         yaml_path = '.tumblr'
@@ -218,6 +219,9 @@ class TumblrDownloader:
         :param url: url of the target data
         :param path: name of the local file
         """
+        if os.path.exists(path) and not self.redownload:
+            return True
+
         while True:
             try:
                 r = requests.get(url, timeout=10)

--- a/tumblr.py
+++ b/tumblr.py
@@ -56,7 +56,7 @@ class TumblrDownloader:
         if not os.path.isdir(self.download_folder):
             os.mkdir(self.download_folder)
 
-    def download_likes(self, start_page=0, max_page=50):
+    def download_likes(self, start_page=0, max_page=50, use_native_filenames=False):
         """
         Download all the posts you liked
         :param start_page: optional, the page number to start, default is 0
@@ -68,7 +68,7 @@ class TumblrDownloader:
         if not os.path.isdir(download_path):
             os.mkdir(download_path)
 
-        names = BlogName(download_path)
+        names = BlogName(download_path) if not use_native_filenames else None
 
         count = 0
         total = self.user_info['likes']


### PR DESCRIPTION
tumblr-downloader has been a great help.  I started making some tweaks to help my particular situation, but wanted to offer them upstream if you want.  I don't speak Chinese, so didn't make extensive modifications to README-zh.md.

1.  The yaml pypi package doesn't exist, but pyyaml works.  I adjusted READMEs to fix pip syntax.  

2.  I often rerun downloads, and I've found filenames in tumble seem to be unchanging.  So I implemented skip logic, defaulted on.  It's possible that a download will be written incompletely, but it's unlikely.  

3.  I was confused at the BlogName feature.  At first, I didn't like it, then I thought it was great, then I realized that different people might have a preference.  So I parameterized it, default behavior is how you originally wrote it.  

4.  Some blogs have HUGE histories, and the 1000 limits ended up being a problem.  After hacking around, I found that, instead of using pagination and offsets, using the before parameter and timestamps let me navigate forever backwards.  So I adjusted the logic to iterate this way.  I found a bug in pytumblr and PR'd a fix (https://github.com/tumblr/pytumblr/pull/120) which is required, I ended up adjusting my venv by hand since it was simplest.  If you like the feature, I can write up and test some pip install magic for users who might not be pythoners, unless yahoo approves my PR quickly.  

I probably should have split each commit into a different PR, sorry about that.  

Thanks so much for writing this tool.  

